### PR TITLE
chore:  Bump `VMware.CloudFoundation.Reporting` from 1.0.0.1001 to 1.0.0.1002.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "/usr/bin/pwsh" >> /etc/shells && \
     pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module PowerVCF -RequiredVersion 2.2.0" && \
     pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module PowerValidatedSolutions -RequiredVersion 1.7.0" && \
     pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module VMware.PowerManagement -RequiredVersion 1.0.0.1002" && \
-    pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module VMware.CloudFoundation.Reporting -RequiredVersion 1.0.0.1001" && \
+    pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module VMware.CloudFoundation.Reporting -RequiredVersion 1.0.0.1002" && \
     find / -name "net45" | xargs rm -rf && \
     echo '$ProgressPreference = "SilentlyContinue"' > /root/.config/powershell/Microsoft.PowerShell_profile.ps1 && \
     tdnf erase -y unzip && \


### PR DESCRIPTION
Bumps `VMware.CloudFoundation.Reporting` from 1.0.0.1001 to 1.0.0.1002.

Signed-off-by: Ryan Johnson <ryan@tenthirtyam.org>